### PR TITLE
avoid listing kubectl plugins

### DIFF
--- a/kbenv.sh
+++ b/kbenv.sh
@@ -130,7 +130,7 @@ function kbenv_uninstall(){
 }
 
 function kbenv_list(){
-    installed_versions="$(find "${KUBECTL_BINARY_PATH}"/ -name '*kubectl*' -printf '%f\n' | sed -r 's/kubectl-?//' | sed '/^$/d' | sort --version-sort)"
+    installed_versions="$(find "${KUBECTL_BINARY_PATH}"/ -name '*kubectl*' -printf '%f\n' | grep -Eo 'v([0-9]\.?)+$' | sed '/^$/d' | sort --version-sort)"
     echo "$installed_versions"
 }
 


### PR DESCRIPTION
I have some custom kubectl plugins in `KUBECTL_BINARY_PATH` and they where showing up in `kbenv list`